### PR TITLE
Fix assertion when adding joints

### DIFF
--- a/newton-4.00/sdk/dCollision/ndBodyKinematic.cpp
+++ b/newton-4.00/sdk/dCollision/ndBodyKinematic.cpp
@@ -203,6 +203,7 @@ ndBodyKinematic::ndJointList::ndNode* ndBodyKinematic::AttachJoint(ndJointBilate
 		bool test = (body0 == bodyInJoint0) && (body1 == bodyInJoint1);
 		test = test || ((body1 == bodyInJoint0) && (body0 == bodyInJoint1));
 		test = test && (body1->GetInvMass() > ndFloat32(0.0f));
+		test = test && bodyJoint->IsActive();
 		if (test)
 		{
 			ndTrace(("warning body %d and body %d already connected by a biletaral joint\n", body0->GetId(), body1->GetId()));


### PR DESCRIPTION
When a joint is added between two bodies where a previous joint has been removed but not cleaned up, I get an assert fails.  Based on our previous conversation around joint lists, I've tried to fix this one by checking if the current joint is still active.